### PR TITLE
Add reservation creation endpoint

### DIFF
--- a/app/Http/Requests/ReservationRequest.php
+++ b/app/Http/Requests/ReservationRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReservationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<string|int, mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'babysitter_id' => ['required', 'integer', 'exists:users,id'],
+            'date'          => ['required', 'date'],
+            'start_time'    => ['required', 'date_format:H:i'],
+            'end_time'      => ['required', 'date_format:H:i', 'after:start_time'],
+            'services'      => ['required', 'array', 'min:1'],
+            'services.*.service_id' => ['required', 'integer', 'exists:services,id'],
+            'services.*.quantity'   => ['required', 'integer', 'min:1'],
+            'services.*.price'      => ['required', 'numeric', 'min:0'],
+            'notes'         => ['nullable', 'string'],
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,9 @@ Route::middleware('auth')->group(
         Route::get('/reservations', [ReservationController::class, 'index'])
             ->name('reservations.index');
 
+        Route::post('/reservations', [ReservationController::class, 'store'])
+            ->name('reservations.store');
+
         Route::post('/reservations/{reservationId}/accept', AcceptReservationController::class)
             ->name('reservations.accept');
         Route::post('/reservations/{reservationId}/cancel', CancelReservationController::class)


### PR DESCRIPTION
## Summary
- add ReservationRequest for validating input
- implement ReservationController@store to handle creating reservations
- register new POST route for reservations

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849d61739fc83248998753e9ff9873a