### PR TITLE
Improve reservation creation form

### DIFF
--- a/resources/js/components/BabysitterList.vue
+++ b/resources/js/components/BabysitterList.vue
@@ -145,7 +145,7 @@ const props = withDefaults(defineProps<{ babysitters: Babysitter[] }>(), {
                                 </div>
                                 <MediaScrollingHorizontalV2 :items="babysitter.media" class="mt-4" />
                                 <div class="mt-4">
-                                    <Link key="book" :href="route('reservations.create', { user: babysitter })">
+                                    <Link key="book" :href="route('reservations.create', { id: babysitter.id })">
                                     <Button class="w-full mt-auto">
                                         Book me
                                     </Button>


### PR DESCRIPTION
## Summary
- dynamically render service lines when creating reservations
- wire up add/remove service line actions
- compute totals and display tax breakdowns
- submit new reservations via a form post
- fix breadcrumb and booking link parameter

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d61b9be08324b1aad41da39abc29